### PR TITLE
Kubernetes Liveness and Readiness Endpoints

### DIFF
--- a/pkg/rtnl/probez.go
+++ b/pkg/rtnl/probez.go
@@ -1,0 +1,51 @@
+package rtnl
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Determines if the server is healthy or not.
+func (s *Server) IsHealthy() bool {
+	s.RLock()
+	defer s.RUnlock()
+	return s.healthy
+}
+
+// Determines if the server is ready or not.
+func (s *Server) IsReady() bool {
+	s.RLock()
+	defer s.RUnlock()
+	return s.ready
+}
+
+// Set the server health state to the status bool.
+func (s *Server) SetHealthy(status bool) {
+	s.Lock()
+	defer s.Unlock()
+	s.healthy = status
+}
+
+// Set the server ready state to the status bool.
+func (s *Server) SetReady(status bool) {
+	s.Lock()
+	defer s.Unlock()
+	s.ready = status
+}
+
+func (s *Server) Healthz(c *gin.Context) {
+	status := http.StatusOK
+	if !s.IsHealthy() {
+		status = http.StatusServiceUnavailable
+	}
+	c.Data(status, "text/plain", []byte(http.StatusText(status)))
+}
+
+func (s *Server) Readyz(c *gin.Context) {
+	status := http.StatusOK
+	if !s.IsReady() {
+		status = http.StatusServiceUnavailable
+	}
+	c.Data(status, "text/plain", []byte(http.StatusText(status)))
+}

--- a/pkg/rtnl/status.go
+++ b/pkg/rtnl/status.go
@@ -28,7 +28,7 @@ func (s *Server) Available() gin.HandlerFunc {
 
 	return func(c *gin.Context) {
 		// Check the health status
-		if s.conf.Maintenance || !s.IsHealthy() {
+		if s.conf.Maintenance || !s.IsReady() {
 			out := api.StatusReply{
 				Status:  status,
 				Uptime:  s.Uptime().String(),


### PR DESCRIPTION
### Scope of changes

Implements kubernetes probe endpoints to signal health and readiness of the service.

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

[Copy acceptance criteria checklist from story for reviewer, or add a brief acceptance criteria here]

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests
- [ ] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?
