### PR TITLE
Shorten and Base62 Code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/rotationalio/confire v1.0.0
 	github.com/rs/zerolog v1.31.0
 	github.com/stretchr/testify v1.8.4
+	github.com/twmb/murmur3 v1.1.8
 	github.com/urfave/cli/v2 v2.25.7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
+github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
+github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=

--- a/pkg/base62/base62.go
+++ b/pkg/base62/base62.go
@@ -1,0 +1,45 @@
+package base62
+
+import (
+	"errors"
+	"math"
+	"strings"
+)
+
+const (
+	alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	length   = uint64(len(alphabet))
+)
+
+var (
+	ErrOverflow = errors.New("input too long for uint64 decoding")
+)
+
+func Encode(num uint64) string {
+	var buf strings.Builder
+	buf.Grow(11)
+
+	for ; num > 0; num = num / length {
+		buf.WriteByte(alphabet[(num % length)])
+	}
+
+	return buf.String()
+}
+
+func Decode(s string) (uint64, error) {
+	if len(s) > 11 {
+		return 0, ErrOverflow
+	}
+
+	var num uint64
+	for i, symbol := range s {
+		pos := strings.IndexRune(alphabet, symbol)
+
+		if pos == -1 {
+			return 0, ErrInvalidCharacter(pos, symbol)
+		}
+		num += uint64(pos) * uint64(math.Pow(float64(length), float64(i)))
+	}
+
+	return num, nil
+}

--- a/pkg/base62/base62_test.go
+++ b/pkg/base62/base62_test.go
@@ -1,0 +1,41 @@
+package base62_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/rotationalio/rtnl.link/pkg/base62"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBase62(t *testing.T) {
+	source := rand.NewSource(time.Now().UnixNano())
+	rand := rand.New(source)
+
+	// Test 1000 random uint64 encode and decode strings
+	for i := 0; i < 1000; i++ {
+		num := rand.Uint64()
+		encoded := base62.Encode(num)
+
+		length := len(encoded)
+		require.GreaterOrEqual(t, length, 5, "expected length to be at least 5 chars")
+		require.LessOrEqual(t, length, 11, "expected length to be at most 11 chars")
+
+		decoded, err := base62.Decode(encoded)
+		require.NoError(t, err, "unable to decode encoded base62 string")
+		require.Equal(t, num, decoded, "decoded num does not match original")
+	}
+}
+
+func TestBase62Invalid(t *testing.T) {
+	testCases := []string{
+		"a&b",
+		"abcdefghijklmnopqrsg",
+	}
+
+	for i, tc := range testCases {
+		_, err := base62.Decode(tc)
+		require.Error(t, err, "expected error on test case %d", i)
+	}
+}

--- a/pkg/base62/errors.go
+++ b/pkg/base62/errors.go
@@ -1,0 +1,16 @@
+package base62
+
+import "fmt"
+
+type InvalidCharacter struct {
+	pos  int
+	char rune
+}
+
+func ErrInvalidCharacter(pos int, char rune) error {
+	return &InvalidCharacter{pos, char}
+}
+
+func (c *InvalidCharacter) Error() string {
+	return fmt.Sprintf("invalid character %s at position %d", string(c.char), c.pos)
+}

--- a/pkg/short/short.go
+++ b/pkg/short/short.go
@@ -1,0 +1,45 @@
+package short
+
+import (
+	"encoding/binary"
+	"net/url"
+
+	"github.com/rotationalio/rtnl.link/pkg/base62"
+	"github.com/twmb/murmur3"
+)
+
+func URL(rawURL string) (_ string, err error) {
+	var u *url.URL
+	if u, err = url.Parse(rawURL); err != nil {
+		return "", err
+	}
+
+	return Shorten(u.String())
+}
+
+func Shorten(s string) (_ string, err error) {
+	// Convert the string into a uint64 using a 64 bit murmur3 hash
+	var sum []byte
+	if sum, err = Hash([]byte(s)); err != nil {
+		return "", err
+	}
+
+	var num uint64
+	if num, err = Numeric(sum); err != nil {
+		return "", err
+	}
+
+	return base62.Encode(num), nil
+}
+
+func Hash(s []byte) ([]byte, error) {
+	hash := murmur3.New64()
+	if _, err := hash.Write([]byte(s)); err != nil {
+		return nil, err
+	}
+	return hash.Sum(nil), nil
+}
+
+func Numeric(s []byte) (uint64, error) {
+	return binary.LittleEndian.Uint64(s), nil
+}

--- a/pkg/short/short_test.go
+++ b/pkg/short/short_test.go
@@ -1,0 +1,44 @@
+package short_test
+
+import (
+	"testing"
+
+	"github.com/rotationalio/rtnl.link/pkg/short"
+	"github.com/stretchr/testify/require"
+)
+
+func TestURL(t *testing.T) {
+	testCases := []struct {
+		in       string
+		expected string
+	}{
+		{"https://rotational.io", "okV7czZRVbs"},
+		{"https://intersog.com/blog/how-to-write-a-custom-url-shortener-using-golang-and-redis/#toc-anchor-4", "2ZnactvxBpn"},
+		{"https://example.com?foo=bar&color=red", "DN2TaxzJOVe"},
+		{"http://localhost:8080/example", "u1QbsHxRQfh"},
+		{"https://example.com/index.html", "D822dZX23Ym"},
+	}
+
+	for i, tc := range testCases {
+		actual, err := short.URL(tc.in)
+		require.NoError(t, err, "could not shorten test case %d", i)
+		require.Equal(t, tc.expected, actual, "mismatch on test case %d", i)
+	}
+}
+
+func TestShorten(t *testing.T) {
+	testCases := []struct {
+		in       string
+		expected string
+	}{
+		{"", ""},
+		{"this is the song that never ends", "NgNExPA3nOd"},
+		{"https://rotational.io", "okV7czZRVbs"},
+	}
+
+	for i, tc := range testCases {
+		actual, err := short.Shorten(tc.in)
+		require.NoError(t, err, "could not shorten test case %d", i)
+		require.Equal(t, tc.expected, actual, "mismatch on test case %d", i)
+	}
+}


### PR DESCRIPTION
### Scope of changes

Implements the shorten methodology which uses a murmur3 64-bit hash to convert a string into a uint64 then uses a base62 encoding algorithm to convert the uint64 to an 8-11 character string that can be decoded back to a uint64. The plan is to use the uint64 (8 bytes) to store the ID of the url (instead of using up to 11 bytes) and the murmur3 hash ensures that duplicate links will be encoded with the same short url. The possibility of collisions does exist, but it is likely very rare. 

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

[Copy acceptance criteria checklist from story for reviewer, or add a brief acceptance criteria here]

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?
