### PR TITLE
Authenticate Link Info

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -93,7 +93,7 @@ func (c *APIv1) ShortenURL(ctx context.Context, in *api.LongURL) (out *api.Short
 }
 
 func (c *APIv1) ShortURLInfo(ctx context.Context, id string) (out *api.ShortURL, err error) {
-	endpoint := fmt.Sprintf("/%s/info", id)
+	endpoint := fmt.Sprintf("/v1/links/%s", id)
 
 	var req *http.Request
 	if req, err = c.NewRequest(ctx, http.MethodGet, endpoint, nil, nil); err != nil {
@@ -108,7 +108,7 @@ func (c *APIv1) ShortURLInfo(ctx context.Context, id string) (out *api.ShortURL,
 }
 
 func (c *APIv1) DeleteShortURL(ctx context.Context, id string) (err error) {
-	endpoint := fmt.Sprintf("/%s", id)
+	endpoint := fmt.Sprintf("/v1/links/%s", id)
 
 	var req *http.Request
 	if req, err = c.NewRequest(ctx, http.MethodDelete, endpoint, nil, nil); err != nil {

--- a/pkg/rtnl/rtnl.go
+++ b/pkg/rtnl/rtnl.go
@@ -227,6 +227,9 @@ func (s *Server) Routes(router *gin.Engine) (err error) {
 		v1.GET("/status", s.Status)
 		v1.POST("/shorten", s.Authenticate, s.ShortenURL)
 		v1.GET("/links", s.Authenticate, s.ShortURLList)
+		v1.POST("/links", s.Authenticate, s.ShortenURL)
+		v1.GET("/links/:id", s.Authenticate, s.ShortURLInfo)
+		v1.DELETE("/links/:id", s.Authenticate, s.DeleteShortURL)
 	}
 
 	// Web Routes
@@ -236,10 +239,8 @@ func (s *Server) Routes(router *gin.Engine) (err error) {
 
 	// Permenant Routes
 	router.GET("/:id", s.Redirect)
+	router.GET("/:id/info", s.ShortURLDetail)
 	router.DELETE("/:id", s.Authenticate, s.DeleteShortURL)
-
-	// TODO: add authentication back to this route!
-	router.GET("/:id/info", s.ShortURLInfo)
 
 	// NotFound and NotAllowed routes
 	router.NoRoute(s.NotFound)

--- a/pkg/rtnl/shorten.go
+++ b/pkg/rtnl/shorten.go
@@ -3,7 +3,6 @@ package rtnl
 import (
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rotationalio/rtnl.link/pkg/api/v1"
@@ -112,7 +111,7 @@ func (s *Server) ShortURLInfo(c *gin.Context) {
 
 	c.Negotiate(http.StatusOK, gin.Negotiate{
 		Offered:  []string{gin.MIMEHTML, gin.MIMEJSON},
-		HTMLName: "info.html",
+		HTMLName: "links_detail.html",
 		HTMLData: out.WebData(),
 		JSONData: out,
 	})
@@ -168,7 +167,6 @@ func (s *Server) ShortURLList(c *gin.Context) {
 	}
 
 	// Retrieve the page from the database
-	time.Sleep(5 * time.Second)
 
 	// Create the API response to send back to the user.
 	out = &api.ShortURLList{}

--- a/pkg/rtnl/templates/info.html
+++ b/pkg/rtnl/templates/info.html
@@ -1,19 +1,8 @@
 {{ template "base" . }}
 {{ define "content" }}
 
-<section class="text-center py-14">
-  <ul>
-    <li>{{ .Info.URL }}</li>
-    <li>{{ .Info.AltURL }}</li>
-    <li>{{ .Info.Title }}</li>
-    <li>{{ .Info.Description }}</li>
-    <li>{{ .Info.Visits }}</li>
-    <li>{{ .Info.Expires }}</li>
-    <li>{{ .Info.Created }}</li>
-    <li>{{ .Info.Modified }}</li>
-    <li>{{ .Info.CampaignID }}</li>
-    <li>{{ .Info.Campaigns }}</li>
-  </ul>
+<section class="text-center py-14" hx-get="/v1/links/{{ .ID }}" hx-trigger="load">
+  <i alt="Loading..." class="fa-solid fa-spinner fa-spin htmx-indicator"></i>
 </section>
 
 {{ end }}

--- a/pkg/rtnl/templates/partials/links_detail.html
+++ b/pkg/rtnl/templates/partials/links_detail.html
@@ -1,0 +1,12 @@
+<ul>
+  <li>{{ .Info.URL }}</li>
+  <li>{{ .Info.AltURL }}</li>
+  <li>{{ .Info.Title }}</li>
+  <li>{{ .Info.Description }}</li>
+  <li>{{ .Info.Visits }}</li>
+  <li>{{ .Info.Expires }}</li>
+  <li>{{ .Info.Created }}</li>
+  <li>{{ .Info.Modified }}</li>
+  <li>{{ .Info.CampaignID }}</li>
+  <li>{{ .Info.Campaigns }}</li>
+</ul>

--- a/pkg/rtnl/web.go
+++ b/pkg/rtnl/web.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rotationalio/rtnl.link/pkg"
 	api "github.com/rotationalio/rtnl.link/pkg/api/v1"
 )
 
@@ -15,4 +16,13 @@ func (s *Server) Index(c *gin.Context) {
 func (s *Server) List(c *gin.Context) {
 	data := api.NewWebData()
 	c.HTML(http.StatusOK, "list.html", data)
+}
+
+func (s *Server) ShortURLDetail(c *gin.Context) {
+	// Get URL parameter from input
+	data := gin.H{
+		"ID":      c.Param("id"),
+		"Version": pkg.Version(),
+	}
+	c.HTML(http.StatusOK, "info.html", data)
 }


### PR DESCRIPTION
### Scope of changes

Adds the authentication method back to the link info page.

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [x] technical debt
- [ ] other (describe)

### Acceptance criteria

Should be able to access the info page only if authenticated.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests
- [ ] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?
